### PR TITLE
More accurate conversion method

### DIFF
--- a/utils/robomimic_convert_action.py
+++ b/utils/robomimic_convert_action.py
@@ -62,8 +62,8 @@ def main(args):
                 first = False
 
             # read pos and ori from robots
-            action_pos[i] = controller.ee_pos
-            action_ori[i] = Rotation.from_matrix(controller.ee_ori_mat).as_rotvec()
+            action_pos[i] = controller.goal_pos
+            action_ori[i] = Rotation.from_matrix(controller.goal_ori).as_rotvec()
 
             # record low dim states
             new_obs = env.get_observation()


### PR DESCRIPTION
I conducted tests on both methods and found that the approach using "goal_rot" and "goal_pos" yields better results with lower error.
![image](https://github.com/lucys0/awe/assets/80608304/58158666-8958-461b-8b66-5edaae1a030d)
goal_rot & goal_pos error

![image](https://github.com/lucys0/awe/assets/80608304/ea4b7950-6f5a-4427-a2e2-c5fb60fd2449)
eef_rot & eef_pos error